### PR TITLE
Make a schedule available and editable (partially)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/Pmant/ioBroker.botvac"
   },
   "dependencies": {
-    "node-botvac": "Pmant/node-botvac",
+    "node-botvac": "PeterVoronov/node-botvac#0.4.2-schedule-write",
     "@iobroker/adapter-core": "^1.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.botvac",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "description": "ioBroker botvac Adapter",
   "author": {
     "name": "Pmant",
@@ -14,6 +14,7 @@
   ],
   "homepage": "https://github.com/Pmant/ioBroker.botvac",
   "license": "MIT",
+  "main": "main.js",
   "keywords": [
     "ioBroker",
     "botvac"
@@ -23,7 +24,7 @@
     "url": "https://github.com/Pmant/ioBroker.botvac"
   },
   "dependencies": {
-    "node-botvac": "^0.1.0",
+    "node-botvac": "Pmant/node-botvac",
     "@iobroker/adapter-core": "^1.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.botvac",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "ioBroker botvac Adapter",
   "author": {
     "name": "Pmant",


### PR DESCRIPTION
This PR bring a new capabilities to the adapter - to see and edit the schedule.

For showing the schedule is new channel under any device (robot) is used - `schedule`.
For each day of week it has from one to three states, depending on type of schedule.

- startTime - time whet robot should start - applicable and mandatory for any type of schedule (`minimal-1`, `basic-1`, `basic-2`)
- mode - eco or turbo mode - applicable and mandatory only for the `basic-1` and `basic-2`
- boundaryId - limitation for the area of work - applicable and optional only for the `basic-2`

It has the appropriate names:

- DoW-startTime
- DoW-mode
- DoW-boundaryID

For Sunday and Wednesday, fro example, it will look like:

- Sunday:
  - `0-StartTime`
  - `0-mode`
  - `0-boundaryID`
- Wednesday:
- `3-StartTime`
- `3-mode`
- `3-boundaryID`

Currently is only `startTime` is editable for any type of schedule.
It is mean:
- you can modify time on any schedule;
- you can delete any day from schedule by emptying the `startTime` for any DoW
- ***but you can add new schedule day, by editing appropriate startTime from empty to the `HH::MM` only if you have 'minimal-1' type of schedule*.** 

Functionality for `basic-1` will come nearest time, but will require testing outside of my environment, as I have only `BotVav D5`.

And it still have a lot of debug messages, if debug mode of adapter will be enabled.

P.S. It still pointed on my fork of `node-botvac` as it required the `setSchedule` function from it.
P.P.S. I is include the some new fields is implemented in version 4.2 of node-botvac. 